### PR TITLE
Add year argument to public BaseDatasource methods

### DIFF
--- a/openelex/base/datasource.py
+++ b/openelex/base/datasource.py
@@ -22,16 +22,16 @@ class BaseDatasource(StateBase):
     Intended to be subclassed in state-specific datasource.py modules.
 
     """
-    def elections(self):
+    def elections(self, year=None):
         raise NotImplementedError()
 
-    def mappings(self):
+    def mappings(self, year=None):
         raise NotImplementedError()
 
-    def target_urls(self):
+    def target_urls(self, year=None):
         raise NotImplementedError()
 
-    def filename_url_pairs(self):
+    def filename_url_pairs(self, year=None):
         "Returns array of tuples of standardized filename, source url pairs"
         raise NotImplementedError()
 


### PR DESCRIPTION
This is a little thing, but caused a moment of friction when I
was getting started.

The invoke tasks appear to pass a year argument to these methods
and the states that are implemented all have the year argument
in their signature.

If a developer doesn't implement one of the required methods in
the state.datasource.Datasource class, a TypeError is raised
because of the mismatched signature instead of the NotImplemented
exception which would have reminded the contributor which methods
they need to implement in their subclass.
