### PR TITLE
Add (raw_)party field to Result, remove from Candidate

### DIFF
--- a/openelex/models.py
+++ b/openelex/models.py
@@ -10,7 +10,7 @@ from mongoengine.fields import (
     ReferenceField,
 )
 from mongoengine.queryset import CASCADE
-
+ 
 from openelex.us import STATE_POSTALS
 
 
@@ -81,7 +81,6 @@ class Candidate(DynamicDocument):
     raw_family_name = StringField(max_length=200)
     raw_suffix = StringField(max_length=200)
     raw_additional_name = StringField(max_length=200, help_text="For middle names, nicknames, etc")
-    raw_parties = ListField(StringField(), default=list)
 
     # FIELDS FOR TRANSFORMED/CLEANED DATA or LINKS TO OTHER DATA SETS
     #name = StringField(max_length=300, required=True)
@@ -90,7 +89,6 @@ class Candidate(DynamicDocument):
     suffix = StringField(max_length=200)
     additional_name = StringField(max_length=200, help_text="For middle names, nicknames, etc")
     other_names = ListField(StringField(), default=list)
-    parties = ListField(StringField(), default=list) # normalized? abbreviations?
     identifiers = DictField()
 
     meta = {
@@ -99,11 +97,6 @@ class Candidate(DynamicDocument):
 
     def __unicode__(self):
         name =  u'%s - %s' % (self.contest_slug, self.name)
-        parties = ""
-        if self.raw_parties:
-            parties = ", ".join([party for party in self.raw_parties])
-            if parties:
-                name += " (%s)" % parties
         return name
 
     @property
@@ -146,11 +139,18 @@ class Result(DynamicDocument):
     raw_winner = StringField()
     raw_write_in = StringField()
     raw_vote_breakdowns = DictField(help_text="If provided, store vote totals for election day, absentee, provisional, etc.")
+    # See https://github.com/openelections/core/issues/46
+    raw_party = StringField(help_text="Party name for the candidate's results. "
+        "This is needed because in some states (NY, CT, SC ...) candidates "
+        "can run as the nominee for multiple parties and results will be "
+        "per-party.")
 
     jurisdiction = StringField(help_text="Derived/standardized political geography, typically when not found in raw results.")
     total_votes = IntField()
     winner = BooleanField(help_text="Winner as determined by OpenElex, if not provided natively in data")
     write_in = BooleanField()
+    party = StringField(help_text="Standardized party name for this candidate's "
+        "results.  Based on raw_party.")
     #vote_breakdowns = DictField(help_text="If provided, store vote totals for election day, absentee, provisional, etc.")
 
     meta = {


### PR DESCRIPTION
Explicitely add `party` and `raw_party` fields to the `Result`
model.  This accomodates the case where a candidate can be the
nominee from multiple parties in states like NY and CT, and reflects
the way that the raw data delivers results on a per-party,
per-candidate basis.

In the case of `us.md.load`, it looks like party was added as a
dynamic field of `Result` in most cases anyway.

Remove these fields from `Candidate`.

Addresses #46
