### PR TITLE
Allow association of validators with transforms

### DIFF
--- a/openelex/base/transform.py
+++ b/openelex/base/transform.py
@@ -1,22 +1,56 @@
-import os
-import re
-import sys
 from collections import OrderedDict
 
 from .state import StateBase
 
 
+class Transform(object):
+    """Wrapper for transform function and its validators"""
+
+    def __init__(self, func, validators=[]):
+        self._func = func
+        self._validators = OrderedDict()
+
+    def add_validation(self, *validators):
+        """
+        Associate validation functions with this transform.
+        """
+        for v in validators:
+            self._validators[v.__name__] = v
+
+    @property
+    def validators(self):
+        return self._validators.values()
+
+    @property
+    def name(self):
+        return self._func.__name__
+
+    def __str__(self):
+        return self.name
+
+    def __call__(self):
+        self._func()
+    run = __call__
+
+    
 class Registry(StateBase):
 
     _registry = {}
 
-    def register(self, state, func):
+    def register(self, state, transform, validators=[]):
         try:
             state_xforms = self._registry[state]
         except KeyError:
             self._registry[state] = OrderedDict()
             state_xforms = self._registry[state]
-        state_xforms[func.func_name] = func
+
+        if isinstance(transform, Transform):
+            transform_obj = transform
+        else:
+            transform_obj = Transform(transform)
+
+        transform_obj.add_validation(*validators)
+        state_xforms[transform_obj.name] = transform_obj 
 
     def get(self, state, func_name):
         try:
@@ -27,7 +61,8 @@ class Registry(StateBase):
         return transform
 
     def all(self, state):
-        return self._registry[state]
+        return self._registry[state].values()
+
 
 # Global object for registering transform functions
 registry = Registry()

--- a/openelex/tasks/validate.py
+++ b/openelex/tasks/validate.py
@@ -60,15 +60,20 @@ def run(state, include=None, exclude=None):
                 validations.pop(val)
 
     # Run remaining validations
+    run_validation(state, validations.values()) 
+
+
+def run_validation(state, validators):
     passed = []
     failed = []
     print
-    for val, func in validations.items():
+    for validator in validators:
         try:
-            func()
-            passed.append(name)
+            validator()
+            passed.append(validator.__name__)
         except Exception as e:
-            failed.append("Error: %s - %s - %s" % (state.upper(), name, e))
+            failed.append("Error: %s - %s - %s" %
+                          (state.upper(), validator.__name__, e))
 
     print "\n\nVALIDATION RESULTS"
     print "Passed: %s" % len(passed)
@@ -76,4 +81,3 @@ def run(state, include=None, exclude=None):
     for fail in failed:
         print "\t%s" % fail
     print
-

--- a/openelex/tests/test_transform_registry.py
+++ b/openelex/tests/test_transform_registry.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from mock import Mock
+
+from openelex.base.transform import registry
+
+class TestTransformRegistry(TestCase):
+    def test_register_with_validators(self):
+        mock_transform = Mock(return_value=None)
+        mock_transform.__name__ = 'mock_transform'
+        mock_validator1 = Mock(return_value=None)
+        mock_validator1.__name__ = 'mock_validator1'
+        mock_validator2 = Mock(return_value=None)
+        mock_validator2.__name__ = 'mock_validator2'
+
+        validators = [mock_validator1, mock_validator2]
+
+        registry.register("XX", mock_transform, validators) 
+
+        transform = registry.get("XX", "mock_transform")
+        self.assertEqual(transform.validators, validators)
+
+        transform()
+        mock_transform.assert_called_once_with()


### PR DESCRIPTION
Create a `Transform` class to wrap the transform function and
aggregate related validators.

Update `Registry.register()` to accept a list of validators.

Return lists when fetching validators and transforms rather than
dicts.  Use func.**name** to get the name.

Factor out the actual running of validation into
`tasks.validate.run_validation` so it can be reused to run
validations with the same output in places other than the
`validate.run` task.

Update the `transform.run` task to run validators associated
with a transform.

Update the `transform.list` task to list validators associated
with a transform.

Addresses #62
