### PR TITLE
Fixed email address typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='Distutils',
     version='0.1.0',
     author='OpenElections',
-    author_email='openelectons@gmail.com',
+    author_email='openelections@gmail.com',
     url='http://openelections.net',
     packages=['distutils', 'distutils.command'],
     scripts=['scripts/manage.py'],


### PR DESCRIPTION
Noticed this in `setup.py`, and it didn't match up with the OpenElections site footer.
