### PR TITLE
Added support for deleting directories in base/cache.py

### DIFF
--- a/openelex/base/cache.py
+++ b/openelex/base/cache.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from openelex import PROJECT_ROOT
 
@@ -30,7 +31,13 @@ class StateCache(object):
 
     def clear(self, datefilter=''):
         files = self.list_dir(datefilter)
-        [os.remove(os.path.join(self.path, f)) for f in files]
+
+        for f in files:
+            try:
+                os.remove(os.path.join(self.path, f))
+            except OSError:
+                shutil.rmtree(os.path.join(self.path, f))
+
         remaining = self.list_dir()
         print "%s files deleted" % len(files)
         print "%s files still in cache" % len(remaining)


### PR DESCRIPTION
In https://github.com/openelections/core/issues/180, `base/cache.py`is unable to remove directories from the cache, thus breaking the ability to remove any files.

I added a simple `try/except` which works with the existing API (`datefilter`) to remove both files and directories. 

If `os.remove()` runs into an `OSError` while trying to remove a directory, `shutil.rmtree()` is called to remove the directory. 
