### PR TITLE
Washington state loader final draft

### DIFF
--- a/openelex/us/wa/load.py
+++ b/openelex/us/wa/load.py
@@ -201,7 +201,7 @@ class LoadResults(object):
         Because of the if/else flow, sometimes we'll end up with multiple
         UnboundLocalErrors. This should be changed so we only get the error
         once.
-        
+
         """
 
         try:
@@ -950,6 +950,16 @@ class WALoaderExcel(WABaseLoader):
 
                     """
                     # logger.info('No party')
+                    pass
+                try:
+                    rr_kwargs.update({
+                            'district': '{0} {1}'.format(
+                                normalize_races(
+                                    sheet.cell(
+                                        rowx=row, colx=self.contest_index)).value.strip(), [
+                                    int(s) for s in sheet.cell(
+                                        rowx=row, colx=self.contest_index).value.strip() if s.isdigit()][0])})
+                except TypeError:
                     pass
         RawResult.objects.insert(results)
 


### PR DESCRIPTION
This updated file includes changes to the normalizing API, and takes all
relevant data from each of the files currently in OpenElection's WA cache.

Unfortunately, due to irregular formats some files aren't able to be
processed at this point. For example, several Excel files have over 100
sheets, all of which take the standard row/column format and switch it.
Some .csv files have no data, and only contain fragmented HTML from when
the file's fetch received a 404 message.

I elected to not include code for those files in this commit because the
amount of time it would take to go through those files would put off the
loader for at least another month, due to my busy schedule. Writing Python
is a little faster than pouring over 20 badly-formatted Excel files with
20+ sheets.

Additionally, many of these Excel files seemed redundant, containing information 
already received from other .csv files. 

This PR also includes changing the requirements.txt file to include an updated 
version of pymongo, as seen here https://github.com/openelections/core/issues/192
