### PR TITLE
Fix editable installs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Turn on your virtual environment from the previous step, if you haven't already:
 $ workon openelex
 ```
 
-Then install the openelex package in [editable mode](http://pip.readthedocs.org/en/latest/reference/pip_install.html#editable-installs)
+Then install the openelex package in [editable mode](https://pip.pypa.io/en/latest/reference/pip_install/#editable-installs)
 
 
 ```bash


### PR DESCRIPTION
The "latest" docs branch for pip appears to be on pypa.io instead of readthedocs, so the link was breaking. The "stable" docs branch appears to live on readthedocs, though, so that one could be used instead if that's better.