### PR TITLE
Pin pymongo to 2.8 in setup.py's install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'mongoengine==0.8.4',
         'nameparser==0.2.7',
         'ordered-set==1.1',
+        'pymongo==2.8',
         'requests>=2.0',
         'unicodecsv==0.9.4',
         'us==0.7',


### PR DESCRIPTION
I was working through the README's getting started instructions, and I got the following error when I tried to load party and office metadata.

```
mongoengine.connection.ConnectionError: Cannot connect to database default :
False is not a read preference.
```

It appears that this issue is due to a version incompatibility between pymongo and mongoengine. This can be fixed by either upgrading mongoengine or downgrading pymongo. I noticed that `stable-req.txt` specifies `pymongo==2.8` so this PR copies that into `setup.py`, where it will be picked up by `pip install -e .`. After this change, I tried again in a clean virtualenv, and I got through all the instructions with no problem.