### PR TITLE
Remove vestigial invoke comments/docstrings/etc.

### DIFF
--- a/openelex/lib/__init__.py
+++ b/openelex/lib/__init__.py
@@ -115,8 +115,8 @@ def format_date(datestr):
     """
     Convert date string into a format used within a searchable data field.
 
-    This is needed because calling code, likely an invoke task uses dates
-    in "%Y%m%d" format and the data store uses dates in "%Y-%m-%d" format.
+    This is needed because calling code uses dates in "%Y%m%d" format and
+    the data store uses dates in "%Y-%m-%d" format.
 
     Args:
         datestr (string): Date string in "%Y%m%d" format.

--- a/openelex/tests/test_md_loader.py
+++ b/openelex/tests/test_md_loader.py
@@ -17,7 +17,7 @@ class TestMDLoader2008Special(MongoTestCase):
             fh = self.loader._file_handle
         except IOError:
             self.skipTest("Cached file for 2008 special election not found. "
-                "Run 'invoke fetch --state=md --datefilter=2008' first.")
+                "Run 'openelex fetch --state=md --datefilter=2008' first.")
 
     def _get_mapping(self):
         for mapping in self.loader.datasource.mappings('2008'): 

--- a/openelex/us/md/datasource.py
+++ b/openelex/us/md/datasource.py
@@ -15,9 +15,9 @@ File-name convention on MD site (2004-2012):
 
     Exceptions: 2000 + 2002
 
-To run mappings from invoke task:
+To run mappings from a shell:
 
-    invoke datasource.mappings -s md
+    openelex datasource.mappings -s md
 
 """
 import re

--- a/stable-req.txt
+++ b/stable-req.txt
@@ -3,7 +3,6 @@ argparse==1.2.1
 beautifulsoup4==4.3.2
 blinker==1.3
 boto==2.9.7
-invoke==0.5.1
 ipython==0.13.2
 jellyfish==0.2.0
 mock==1.0.1


### PR DESCRIPTION
Invoke isn't used anymore, this updates copy to reflect that, and removes it from `stable-req.txt`.

P.S. I ran across this because I accidentally checked out master instead of dev. Could you clean out master and other already-merged branches in this repository? Thanks!