### PR TITLE
Fix encoding and fill in Write In column for WI results

### DIFF
--- a/openelex/base/load.py
+++ b/openelex/base/load.py
@@ -100,7 +100,7 @@ class BaseLoader(StateBase):
 
     @property
     def _file_handle(self):
-        return io.open(join(self.cache.abspath, self.source), 'rU', encoding='latin-1')
+        return io.open(join(self.cache.abspath, self.source), 'rbU')
 
     @property
     def _xls_file_path(self):

--- a/openelex/us/wi/load.py
+++ b/openelex/us/wi/load.py
@@ -47,7 +47,7 @@ class WIPrecinctLoader(WIBaseLoader):
         if not(exists(join(self.cache.abspath, self.source))):
             return
         with self._file_handle as csvfile:
-            reader = csv.DictReader(csvfile)
+            reader = csv.DictReader(csvfile, encoding='utf8')
             next(reader, None)
             for row in reader:
                 rr_kwargs = self._common_kwargs.copy()
@@ -79,12 +79,10 @@ class WIPrecinctLoader(WIBaseLoader):
         }
 
     def _build_candidate_kwargs(self, row):
-        name = row['candidate'].strip()
-        write_in = (name.find('(Write-In)') != -1 ) or (name.find('(Write In)') != -1 )
-        if write_in:
-            write_in = True
-            name = row['candidate'].rstrip('(Write-In)').rstrip('(Write In)').strip()
+        original_name = row['candidate'].strip()
+        clean_name = original_name.replace(' (Write-In)', '').replace(' (Write In)', '')
+        write_in = (original_name != clean_name)
         return {
-            'full_name': name,
+            'full_name': clean_name,
             'write_in': write_in
         }

--- a/openelex/us/wi/load.py
+++ b/openelex/us/wi/load.py
@@ -79,6 +79,12 @@ class WIPrecinctLoader(WIBaseLoader):
         }
 
     def _build_candidate_kwargs(self, row):
+        name = row['candidate'].strip()
+        write_in = (name.find('(Write-In)') != -1 ) or (name.find('(Write In)') != -1 )
+        if write_in:
+            write_in = True
+            name = row['candidate'].rstrip('(Write-In)').rstrip('(Write In)').strip()
         return {
-            'full_name': row['candidate'].strip()
+            'full_name': name,
+            'write_in': write_in
         }


### PR DESCRIPTION
This addresses two things:

1. Wisconsin has some candidate names that include non-latin characters (Juan Colás for example). The ideal way to handle it seemed to be opening the file in binary and then reading the CSV contents using UTF-8.

2. For Wisconsin results, write-in candidates have `(Write-In)` in the candidate name. Now when baking results, that will be removed from the candidate name and the `write-in` column will be filled in based on whether that occurred. See issue: https://github.com/openelections/openelections-core/issues/274