### PR TITLE
Fix failing TestApi test

### DIFF
--- a/openelex/tests/test_api.py
+++ b/openelex/tests/test_api.py
@@ -42,9 +42,7 @@ class FakeApiResponse(object):
         tests_dir = abspath(dirname(__file__))
         fixture_path = join(tests_dir, 'fixtures/election_api_response_md.json')
         with open(fixture_path, 'r') as f:
-            md_data = f.read()
-
-        self.content = md_data
+            self.content = f.read()
 
     def json(self):
         return json.loads(self.content)

--- a/openelex/tests/test_api.py
+++ b/openelex/tests/test_api.py
@@ -38,12 +38,14 @@ fixture_path = join(tests_dir, 'fixtures/election_api_response_md.json')
 with open(fixture_path, 'r') as f:
     md_data = f.read()
 
-
 class FakeApiResponse(object):
 
     def __init__(self, status):
         self.status_code = status
         self.content = md_data
+
+    def json(self):
+        return json.loads(md_data)
 
 
 class TestApi(TestCase):

--- a/openelex/tests/test_api.py
+++ b/openelex/tests/test_api.py
@@ -33,19 +33,21 @@ class TestUrlBuilder(TestCase):
         actual = prepare_api_params(unordered)
         self.assertEquals(expected, actual)
 
-tests_dir = abspath(dirname(__file__))
-fixture_path = join(tests_dir, 'fixtures/election_api_response_md.json')
-with open(fixture_path, 'r') as f:
-    md_data = f.read()
 
 class FakeApiResponse(object):
 
     def __init__(self, status):
         self.status_code = status
+
+        tests_dir = abspath(dirname(__file__))
+        fixture_path = join(tests_dir, 'fixtures/election_api_response_md.json')
+        with open(fixture_path, 'r') as f:
+            md_data = f.read()
+
         self.content = md_data
 
     def json(self):
-        return json.loads(md_data)
+        return json.loads(self.content)
 
 
 class TestApi(TestCase):

--- a/openelex/tests/test_api.py
+++ b/openelex/tests/test_api.py
@@ -54,7 +54,7 @@ class TestApi(TestCase):
 
     @patch('openelex.api.elections.get')
     def test_find(self, mock_get):
-        "openelex.api.find method checks response status and returns array of elections"
+        "openelex.api.elections.find method checks response status and returns array of elections"
         mock_get.return_value = FakeApiResponse(200)
         elecs = api.elections.find('md', None)
         self.assertEquals(len(elecs), 15)

--- a/openelex/tests/test_api.py
+++ b/openelex/tests/test_api.py
@@ -52,5 +52,5 @@ class TestApi(TestCase):
     def test_find(self, mock_get):
         "openelex.api.find method checks response status and returns array of elections"
         mock_get.return_value = FakeApiResponse(200)
-        elecs = api.elections.find('md')
+        elecs = api.elections.find('md', None)
         self.assertEquals(len(elecs), 15)


### PR DESCRIPTION
This fixes the failing `TestApi` test by addressing the following:

* The call to `openelex.api.elections.find` was missing the second `date` argument.
* The object mocking `openelex.api.elections.get` was missing the `json` method.

We also took the opportunity to fix an incorrect comment, and limit the scope of some variables involved in loading the test data.
