### PR TITLE
Fix failing TestUrlBuilder tests

### DIFF
--- a/openelex/tests/test_api.py
+++ b/openelex/tests/test_api.py
@@ -13,7 +13,7 @@ class TestUrlBuilder(TestCase):
 
     def test_default_params(self):
         "default params should include format and limit"
-        expected = OrderedDict([('format', 'json'), ('limit', '0')])
+        expected = OrderedDict()
         actual = prepare_api_params({})
         self.assertEquals(expected, actual)
 
@@ -27,7 +27,6 @@ class TestUrlBuilder(TestCase):
 
         ordered = params[:]
         ordered.sort()
-        ordered.extend([('format', 'json'), ('limit', '0')])
         expected = OrderedDict(ordered)
 
         actual = prepare_api_params(unordered)


### PR DESCRIPTION
This fixes the failing `TestUrlBuilder` tests by removing some legacy entries from the expected default parameters.

The `format` entry was removed in revision aa73685b25, and the `limit` entry was removed in revision fd2c1b12a1.

