### PR TITLE
Fix incorrect name for CA special elections

### DIFF
--- a/openelex/us/ca/datasource.py
+++ b/openelex/us/ca/datasource.py
@@ -67,7 +67,7 @@ class Datasource(BaseDatasource):
                         "raw_url": result['url'],
                         "pre_processed_url": build_raw_github_url(self.state, str(year), result['path']),
                         "ocd_id": ocd_id,
-                        "name": 'Mississippi',
+                        "name": 'California',
                         "election": election['slug']
                     })
             else:


### PR DESCRIPTION
This was likely the result of a copy/paste error.

This fixes #282.