### PR TITLE
tests: replace deprecated assertEquals with assertEqual

### DIFF
--- a/openelex/tests/test_api.py
+++ b/openelex/tests/test_api.py
@@ -15,7 +15,7 @@ class TestUrlBuilder(TestCase):
         "default params should include format and limit"
         expected = OrderedDict()
         actual = prepare_api_params({})
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_default_params_values(self):
         "params should always be alphabetized, and end with format and limit"
@@ -30,7 +30,7 @@ class TestUrlBuilder(TestCase):
         expected = OrderedDict(ordered)
 
         actual = prepare_api_params(unordered)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
 
 class FakeApiResponse(object):
@@ -54,4 +54,4 @@ class TestApi(TestCase):
         "openelex.api.elections.find method checks response status and returns array of elections"
         mock_get.return_value = FakeApiResponse(200)
         elecs = api.elections.find('md', None)
-        self.assertEquals(len(elecs), 15)
+        self.assertEqual(len(elecs), 15)

--- a/openelex/tests/test_md_datasource.py
+++ b/openelex/tests/test_md_datasource.py
@@ -159,55 +159,55 @@ class TestSourceUrlBuilder(TestCase):
 
     def test_build_state_leg_urls(self):
         # supplying only a year returns a state legislative url for a general election
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2012/election_data/State_Legislative_Districts_2012_General.csv",
             self.datasource._build_state_leg_url(2012)
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2012/election_data/State_Legislative_Districts_Democratic_2012_Primary.csv",
             self.datasource._build_state_leg_url(2012, 'Democratic')
         )
         # 2000 and 2004 end with the year
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2004/election_data/State_Legislative_Districts_General_2004.csv",
             self.datasource._build_state_leg_url(2004)
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2000/election_data/State_Legislative_Districts_General_2000.csv",
             self.datasource._build_state_leg_url(2000)
         )
 
     def test_build_county_urls(self):
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2012/election_data/Allegany_County_2012_General.csv",
             self.datasource._build_county_url(2012, 'Allegany')
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2012/election_data/Allegany_By_Precinct_2012_General.csv",
             self.datasource._build_county_url(2012, 'Allegany', precinct=True)
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2012/election_data/Allegany_County_Democratic_2012_Primary.csv",
             self.datasource._build_county_url(2012, 'Allegany', 'Democratic')
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2012/election_data/Allegany_By_Precinct_Democratic_2012_Primary.csv",
             self.datasource._build_county_url(2012, 'Allegany', 'Democratic', precinct=True)
         )
         # 2000 and 2004 files end with the 4-digit year and do not use the _County"
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2004/election_data/Allegany_General_2004.csv",
             self.datasource._build_county_url(2004, 'Allegany')
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2004/election_data/Allegany_Democratic_Primary_2004.csv",
             self.datasource._build_county_url(2004, 'Allegany', 'Democratic')
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2000/election_data/Allegany_General_2000.csv",
             self.datasource._build_county_url(2000, 'Allegany')
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2000/election_data/Allegany_By_Precinct_General_2000.csv",
             self.datasource._build_county_url(2000, 'Allegany', precinct=True)
         )
@@ -218,11 +218,11 @@ class TestSourceUrlBuilder(TestCase):
             "http://www.elections.state.md.us/elections/2002/results/g_all_offices.txt"},
             set(self.datasource._get_2002_source_urls())
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2002/results/g_all_offices.txt",
             self.datasource._get_2002_source_urls('general')
         )
-        self.assertEquals(
+        self.assertEqual(
             "http://www.elections.state.md.us/elections/2002/results/p_all_offices.txt",
             self.datasource._get_2002_source_urls('primary')
         )
@@ -246,58 +246,58 @@ class TestStandardizedFilenames(TestCase):
     def test_state_leg_filename_general_racewide_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2012/election_data/State_Legislative_Districts_2012_General.csv"
         actual = self.datasource._generate_state_leg_filename(raw_url, '2012-11-06')
-        self.assertEquals('20121106__md__general__state_legislative.csv', actual)
+        self.assertEqual('20121106__md__general__state_legislative.csv', actual)
 
     def test_state_leg_filename_primary_racewide_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2012/election_data/State_Legislative_Districts_Democratic_2012_Primary.csv"
         actual = self.datasource._generate_state_leg_filename(raw_url, '2012-04-03')
-        self.assertEquals("20120403__md__democratic__primary__state_legislative.csv", actual)
+        self.assertEqual("20120403__md__democratic__primary__state_legislative.csv", actual)
 
     def test_county_filename_general_county_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2012/election_data/Allegany_County_2012_General.csv"
         actual = self.datasource._generate_county_filename(raw_url, '2012-11-06', self.allegany_jurisdiction)
-        self.assertEquals("20121106__md__general__allegany.csv", actual)
+        self.assertEqual("20121106__md__general__allegany.csv", actual)
 
     def test_county_filename_general_precinct_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2012/election_data/Allegany_By_Precinct_2012_General.csv"
         actual = self.datasource._generate_county_filename(raw_url, '2012-11-06', self.allegany_jurisdiction)
-        self.assertEquals("20121106__md__general__allegany__precinct.csv", actual)
+        self.assertEqual("20121106__md__general__allegany__precinct.csv", actual)
 
     def test_county_filename_primary_countywide_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2012/election_data/Allegany_County_Democratic_2012_Primary.csv"
         actual = self.datasource._generate_county_filename(raw_url, '2012-04-03', self.allegany_jurisdiction)
-        self.assertEquals("20120403__md__democratic__primary__allegany.csv", actual)
+        self.assertEqual("20120403__md__democratic__primary__allegany.csv", actual)
 
     def test_county_filename_primary_precinct_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2012/election_data/Allegany_By_Precinct_Democratic_2012_Primary.csv"
         actual = self.datasource._generate_county_filename(raw_url, '2012-04-03', self.allegany_jurisdiction)
-        self.assertEquals("20120403__md__democratic__primary__allegany__precinct.csv", actual)
+        self.assertEqual("20120403__md__democratic__primary__allegany__precinct.csv", actual)
 
     # 2000 and 2004 files end with the 4-digit year
     def test_2000_state_leg_filename_general_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2000/election_data/State_Legislative_Districts_General_2000.csv"
         actual = self.datasource._generate_state_leg_filename(raw_url, '2000-11-07')
-        self.assertEquals("20001107__md__general__state_legislative.csv",  actual)
+        self.assertEqual("20001107__md__general__state_legislative.csv",  actual)
 
     def test_2004_state_leg_filename_general_countywide_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2004/election_data/State_Legislative_Districts_General_2004.csv"
         actual = self.datasource._generate_state_leg_filename(raw_url, '2004-11-02')
-        self.assertEquals("20041102__md__general__state_legislative.csv", actual)
+        self.assertEqual("20041102__md__general__state_legislative.csv", actual)
 
     def test_2004_county_filename_general_countywide_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2004/election_data/Allegany_County_General_2004.csv"
         actual = self.datasource._generate_county_filename(raw_url, '2004-11-02', self.allegany_jurisdiction)
-        self.assertEquals("20041102__md__general__allegany.csv", actual)
+        self.assertEqual("20041102__md__general__allegany.csv", actual)
 
     def test_2004_county_filename_primary_precinct_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2004/election_data/Allegany_County_Democratic_Primary_2004.csv"
         actual = self.datasource._generate_county_filename(raw_url, '2004-03-02', self.allegany_jurisdiction)
-        self.assertEquals("20040302__md__democratic__primary__allegany.csv", actual)
+        self.assertEqual("20040302__md__democratic__primary__allegany.csv", actual)
 
     def test_2000_county_filename_general_countywide_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2000/election_data/Allegany_County_General_2000.csv"
         actual = self.datasource._generate_county_filename(raw_url, '2000-11-07', self.allegany_jurisdiction)
-        self.assertEquals("20001107__md__general__allegany.csv", actual)
+        self.assertEqual("20001107__md__general__allegany.csv", actual)
 
     def test_2000_county_filename_precinct_results(self):
         raw_url = "http://www.elections.state.md.us/elections/2000/election_data/Allegany_By_Precinct_2000.csv"
@@ -312,9 +312,9 @@ class TestStandardizedFilenames(TestCase):
     def test_2002_general_filename(self):
         raw_url = "http://www.elections.state.md.us/elections/2002/results/g_all_offices.txt"
         actual = self.datasource._generate_2002_filename(raw_url)
-        self.assertEquals("20021105__md__general.txt", actual)
+        self.assertEqual("20021105__md__general.txt", actual)
 
     def test_2002_primary_filename(self):
         raw_url = "http://www.elections.state.md.us/elections/2002/results/p_all_offices.txt"
         actual = self.datasource._generate_2002_filename(raw_url)
-        self.assertEquals("20020910__md__primary.txt", actual)
+        self.assertEqual("20020910__md__primary.txt", actual)


### PR DESCRIPTION
`assertEquals` (and friends) have been deprecated aliases since Python 3.2. Swap the 30 call sites in `test_api.py` and `test_md_datasource.py` for the non-deprecated `assertEqual` form. No behaviour change.