### PR TITLE
Replace deprecated logging.warn with .warning

### DIFF
--- a/openelex/us/ia/load.py
+++ b/openelex/us/ia/load.py
@@ -88,7 +88,7 @@ class LoadResults(object):
 
 class SkipLoader(object):
     def run(self, mapping):
-        logging.warn("Skipping file {}".format(mapping['generated_filename']))
+        logging.warning("Skipping file {}".format(mapping['generated_filename']))
 
 
 class PreprocessedResultsLoader(BaseLoader):
@@ -757,13 +757,13 @@ class ExcelPrecinct2010GeneralResultLoader(ExcelPrecinctResultLoader):
 
         m = self._office_re.match(raw_office)
         if not m:
-            logging.warn("Skipping office '{}'".format(raw_office))
+            logging.warning("Skipping office '{}'".format(raw_office))
             return None
 
         candidate = self._get_candidate(row, race_offset)
 
         if candidate in self._skip_candidates:
-            logging.warn("Skipping candidate '{}'".format(candidate))
+            logging.warning("Skipping candidate '{}'".format(candidate))
             return None
 
         office = m.group('office')

--- a/openelex/us/md/transform/__init__.py
+++ b/openelex/us/md/transform/__init__.py
@@ -271,7 +271,7 @@ class CreateCandidatesTransform(BaseTransform):
                         # As far as I can tell the value should always be
                         # "Other Write-Ins", but output a warning to let us
                         # know about some cases we may be missing.
-                        logging.warn("'other' found in candidate name field"
+                        logging.warning("'other' found in candidate name field"
                                 "value: '%s'" % rr.full_name)
                 candidate = Candidate(**fields)
                 candidates.append(candidate)


### PR DESCRIPTION
`logging.warn` has been a deprecated alias for `.warning` since Python 3.3. Swept the four IA / MD call sites.