### PR TITLE
Narrow bare excepts in id/oh datasources

### DIFF
--- a/openelex/us/id/datasource.py
+++ b/openelex/us/id/datasource.py
@@ -90,7 +90,7 @@ class Datasource(BaseDatasource):
                     links['general_state_legislature'] = 'http://www.sos.idaho.gov/elect/'+link['href']
         try:
             links['primary_state_legislature']
-        except:
+        except KeyError:
             print(links)
         return [links['primary_statewide'], links['primary_state_legislature']], [links['general_statewide'], links['general_state_legislature']]
     

--- a/openelex/us/oh/datasource.py
+++ b/openelex/us/oh/datasource.py
@@ -92,12 +92,12 @@ class Datasource(BaseDatasource):
 
         try:
             general = [e for e in elections if e['race_type'] == 'general'][0]
-        except:
+        except IndexError:
             general = None
 
         try:
             primary = [e for e in elections if e['race_type'] == 'primary'][0]
-        except:
+        except IndexError:
             primary = None
 
         if general:


### PR DESCRIPTION
Idaho's `links` check really catches `KeyError`, and Ohio's first-match filters catch `IndexError` when no election of that `race_type` exists. Naming them stops an unrelated bug in this code from getting silently swallowed.